### PR TITLE
fix typo: resources should be templates

### DIFF
--- a/docs/structure.html
+++ b/docs/structure.html
@@ -72,7 +72,7 @@
 ├── resources
 │   ├── public
 │   │   ⋮
-│   └── resources
+│   └── templates
 │       ├── asc
 │       │   ├── pages
 │       │   │   └── adoc-page.asc


### PR DESCRIPTION
Hello, I was reading the cryogen documentation and I thought it was peculiar that there should be a directory named `resources` nested underneath a directory with the same name. When I read on past the diagram I saw that the directory under `resources` had been accidentally mislabeled and should be `templates` as per the table below the diagram that reads "resources - This is where all of your site content and configuration will go. It's divided into the _templates_ folder and the _public_ folder."
