### PR TITLE
Quick Start for the CLI is wrong

### DIFF
--- a/index.html
+++ b/index.html
@@ -91,7 +91,7 @@
             <p class="title">Quick Start Guide</p><code class="bash"><span class="dir">~ </span><span
                 class="prompt">$ </span><span class="cmd">lein new cryogen my-blog</span><span class="comment"> # or: </span>
 <span class="dir">~ </span><span
-                    class="prompt">$ </span><span class="cmd">clojure -X:new create :template cryogen :name me.my-blog</span>
+                    class="prompt">$ </span><span class="cmd">clojure -X:new :template cryogen :name me.my-blog</span>
 <span class="dir">~ </span><span class="prompt">$ </span><span class="cmd">cd *my-blog</span>
 <span class="dir">~/my-blog </span><span class="prompt">$ </span><span
 class="cmd">lein serve</span>


### PR DESCRIPTION
It says `clojure -X:new create :template cryogen ...` but the `clj-new` README specifies that `:new` should have `:exec-fn clj-new/create` so you _must not specify `create` in the command_.

This PR fixes that instruction. I have not checked whether other parts of the documentation make this mistake.